### PR TITLE
Fix invalid useNavigation hook usage

### DIFF
--- a/src/Cardapio.tsx
+++ b/src/Cardapio.tsx
@@ -2,14 +2,15 @@ import React from "react";
 import { SafeAreaView, Text, StyleSheet } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 
-const navigation = useNavigation();
+export function Cardapio() {
+  // Example navigation usage
+  const navigation = useNavigation();
 
-export function Cardapio(){
-    return(
-     <SafeAreaView>
-        <Text>Aqui vai o Cardapio</Text>
-     </SafeAreaView>
-    )
+  return (
+    <SafeAreaView>
+      <Text>Aqui vai o Cardapio</Text>
+    </SafeAreaView>
+  );
 }
 
 const style = StyleSheet.create({

--- a/src/Estoque.tsx
+++ b/src/Estoque.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { Text, StyleSheet, SafeAreaView } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 
-const navigation = useNavigation;
+export function Estoque() {
+  const navigation = useNavigation();
 
-export function Estoque(){
-    return (
-        <SafeAreaView>
-            <Text>Aqui vai aparecer o estoque</Text>
-        </SafeAreaView>
-    )
+  return (
+    <SafeAreaView>
+      <Text>Aqui vai aparecer o estoque</Text>
+    </SafeAreaView>
+  );
 }

--- a/src/ModoCozinha.tsx
+++ b/src/ModoCozinha.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-import { SafeAreaView, View, Text, StyleSheet } from "react-native";
+import { SafeAreaView, StyleSheet } from "react-native";
 import { BotaoCard } from "../assets/components/BotaoCard";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList } from './routes/types'; // ajuste o caminho se necessário
-
-
-const navigation = useNavigation()
+import { RootStackParamList } from './routes/types';
 
 export function ModoCozinha() {
+  const navigation = useNavigation();
+
   return (
     <SafeAreaView style={styles.container}>
       <BotaoCard
@@ -23,11 +22,11 @@ export function ModoCozinha() {
         onPress={() => navigation.navigate('Estoque')}
       />
     </SafeAreaView>
-  )
+  );
 }
+
 const styles = StyleSheet.create({
   container: {
     backgroundColor: '#264653',
-
-  }
-})
+  },
+});


### PR DESCRIPTION
## Summary
- fix invalid hook usage in Cardapio, Estoque and ModoCozinha screens

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c236370e48320b0151f9e70d9b4a2