### PR TITLE
Fix navigation typing in ModoCozinha

### DIFF
--- a/src/ModoCozinha.tsx
+++ b/src/ModoCozinha.tsx
@@ -2,11 +2,14 @@ import React from "react";
 import { SafeAreaView, StyleSheet } from "react-native";
 import { BotaoCard } from "../assets/components/BotaoCard";
 import { useNavigation } from "@react-navigation/native";
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList } from './routes/types';
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { RootStackParamList } from "./routes/types";
+
+type ModoCozinhaScreenProps =
+  NativeStackNavigationProp<RootStackParamList, "ModoCozinha">;
 
 export function ModoCozinha() {
-  const navigation = useNavigation();
+  const navigation = useNavigation<ModoCozinhaScreenProps>();
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
## Summary
- correctly type navigation in `ModoCozinha` screen so `.navigate()` works

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'expo', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c299559c883209ad25cc107acbfd5